### PR TITLE
add php7 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+- 7.0
 - 5.6
 - 5.5
 - 5.4


### PR DESCRIPTION
I've pull this down and ran phpunit with `PHP 7.0.0` and it ran swimmingly. Lets see if travis likes it.